### PR TITLE
Mimic WPF MessageBox default button focus and alt AccessKey behavior

### DIFF
--- a/ModernWpf.MessageBox.Test/App.xaml.cs
+++ b/ModernWpf.MessageBox.Test/App.xaml.cs
@@ -18,6 +18,8 @@ namespace ModernWpfMessageBox.Test {
             ModernWpf.MessageBox.Show("redadwada", null, MessageBoxButton.OK, Symbol.Admin);
             ModernWpf.MessageBox.Show("redadwada", null, MessageBoxButton.OK, SymbolGlyph.Airplane);
             ModernWpf.MessageBox.ShowAsync(message, title, MessageBoxButton.YesNoCancel, MessageBoxImage.Question).GetAwaiter().GetResult();
+            ModernWpf.MessageBox.EnableLocalization = false;
+            ModernWpf.MessageBox.ShowAsync("Press Alt and you should see underscores!", null, MessageBoxButton.YesNoCancel, MessageBoxImage.Hand).GetAwaiter().GetResult();
             Shutdown();
         }
     }

--- a/ModernWpf.MessageBox/MessageBoxWindow.xaml
+++ b/ModernWpf.MessageBox/MessageBoxWindow.xaml
@@ -17,9 +17,9 @@
             <TextBlock x:Name="messageText" TextWrapping="Wrap" VerticalAlignment="Center" Height="Auto" MaxWidth="375" />
         </ui:SimpleStackPanel>
         <ui:SimpleStackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
-            <Button x:Name="okButton" Content="Ok" MinWidth="75" Visibility="Collapsed" Padding="12 6 12 6" />
-            <Button x:Name="yesButton" Content="Yes" MinWidth="75" Visibility="Collapsed" Padding="12 6 12 6" />
-            <Button x:Name="noButton" Content="No" MinWidth="75" Visibility="Collapsed" Padding="12 6 12 6" />
+            <Button x:Name="okButton" Content="_Ok" MinWidth="75" Visibility="Collapsed" Padding="12 6 12 6" />
+            <Button x:Name="yesButton" Content="_Yes" MinWidth="75" Visibility="Collapsed" Padding="12 6 12 6" />
+            <Button x:Name="noButton" Content="_No" MinWidth="75" Visibility="Collapsed" Padding="12 6 12 6" />
             <Button x:Name="cancelButton" Content="Cancel" MinWidth="75" Visibility="Collapsed" Padding="12 6 12 6" />
         </ui:SimpleStackPanel>
     </ui:SimpleStackPanel>

--- a/ModernWpf.MessageBox/MessageBoxWindow.xaml.cs
+++ b/ModernWpf.MessageBox/MessageBoxWindow.xaml.cs
@@ -19,15 +19,20 @@ namespace ModernWpf {
                     if (MessageBox.EnableLocalization) {
                         okButton.Content = LocalizedDialogCommands.GetString(DialogBoxCommand.IDOK);
                     }
+
+                    okButton.Focus();
                     break;
                 case MessageBoxButton.OKCancel:
                     okButton.Visibility = Visibility.Visible;
                     cancelButton.Visibility = Visibility.Visible;
+                    cancelButton.IsCancel = true;
 
                     if (MessageBox.EnableLocalization) {
                         okButton.Content = LocalizedDialogCommands.GetString(DialogBoxCommand.IDOK);
                         cancelButton.Content = LocalizedDialogCommands.GetString(DialogBoxCommand.IDCANCEL);
                     }
+                    
+                    okButton.Focus();
                     break;
                 case MessageBoxButton.YesNo:
                     yesButton.Visibility = Visibility.Visible;
@@ -37,17 +42,22 @@ namespace ModernWpf {
                         yesButton.Content = LocalizedDialogCommands.GetString(DialogBoxCommand.IDYES);
                         noButton.Content = LocalizedDialogCommands.GetString(DialogBoxCommand.IDNO);
                     }
+
+                    yesButton.Focus();
                     break;
                 case MessageBoxButton.YesNoCancel:
                     yesButton.Visibility = Visibility.Visible;
                     noButton.Visibility = Visibility.Visible;
                     cancelButton.Visibility = Visibility.Visible;
+                    cancelButton.IsCancel = true;
 
                     if (MessageBox.EnableLocalization) {
                         yesButton.Content = LocalizedDialogCommands.GetString(DialogBoxCommand.IDYES);
                         noButton.Content = LocalizedDialogCommands.GetString(DialogBoxCommand.IDNO);
                         cancelButton.Content = LocalizedDialogCommands.GetString(DialogBoxCommand.IDCANCEL);
                     }
+
+                    yesButton.Focus();
                     break;
             }
 


### PR DESCRIPTION
Makes the ModernWpf.MessageBox behave the same as the standard WPF MessageBox in regards to default button focus and AccessKeys.
Due to the way the current implementation for localization replaces the content of the buttons, I'm not sure of a safe way to keep the underscores on the correct key.
One option may be to simply prefix the result of LocalizedDialogCommands.GetString() with _.. However I do not know if this will be a safe or proper option for all languages?

![image](https://user-images.githubusercontent.com/2175630/145148017-1cb3b7fe-7cb8-4f7b-ab50-605bae38485c.png)
![image](https://user-images.githubusercontent.com/2175630/145148040-1ca8b7e6-9ccf-47ac-b7ae-5ae96c5de11e.png)